### PR TITLE
CI修正: deploy workflow の `actions/checkout` バージョンを修正

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3


### PR DESCRIPTION
### Motivation
- `actions/checkout@v6` のバージョン解決で GitHub Actions が失敗し、Cloud Run デプロイの CI が落ちていたため、実行可能な checkout バージョンに戻してワークフローを復旧する。 

### Description
- `.github/workflows/deploy-cloud-run.yml` の `Checkout` ステップを `actions/checkout@v6` から `actions/checkout@v4` に変更した。 

### Testing
- ローカルで `npm run build`（`next build` を含む）が正常終了することを確認済み。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15954b11188326831968284ac73919)